### PR TITLE
syntax 752 fix

### DIFF
--- a/src/instructions/zcl_wasm_select_star.clas.abap
+++ b/src/instructions/zcl_wasm_select_star.clas.abap
@@ -11,7 +11,8 @@ ENDCLASS.
 CLASS zcl_wasm_select_star IMPLEMENTATION.
 
   METHOD parse.
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       io_body->shift( 1 ).
     ENDDO.
 * todo, pass types to constructor

--- a/src/parsing/sections/zcl_wasm_code_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_code_section.clas.abap
@@ -19,7 +19,8 @@ CLASS zcl_wasm_code_section IMPLEMENTATION.
     DATA lt_locals TYPE zcl_wasm_module=>ty_locals.
     DATA lt_instructions TYPE zif_wasm_instruction=>ty_list.
 
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
 
       DATA(lv_code_size) = io_body->shift_u32( ).
 

--- a/src/parsing/sections/zcl_wasm_data_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_data_section.clas.abap
@@ -58,7 +58,8 @@ CLASS zcl_wasm_data_section IMPLEMENTATION.
 
     ro_data = NEW zcl_wasm_data_section( ).
 
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       DATA(lv_index) = sy-index - 1.
       DATA(lv_type) = io_body->shift_u32( ).
       CLEAR lt_instructions.

--- a/src/parsing/sections/zcl_wasm_element_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_element_section.clas.abap
@@ -101,7 +101,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
 
     ro_section = NEW #( ).
 
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       CLEAR ls_element.
       ls_element-type = io_body->shift_u32( ).
 
@@ -120,13 +121,15 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
             RAISE EXCEPTION TYPE zcx_wasm EXPORTING text = |parse_element: expected end|.
           ENDIF.
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 1.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 2.
@@ -144,13 +147,15 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
 
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 3.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 4.
@@ -167,7 +172,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
             RAISE EXCEPTION TYPE zcx_wasm EXPORTING text = |parse_element: expected end|.
           ENDIF.
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body
@@ -182,7 +188,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
         WHEN 5.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body
@@ -209,7 +216,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
 
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body
@@ -224,7 +232,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
         WHEN 7.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DO io_body->shift_u32( ) TIMES.
+          DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body

--- a/src/parsing/sections/zcl_wasm_element_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_element_section.clas.abap
@@ -121,15 +121,15 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
             RAISE EXCEPTION TYPE zcx_wasm EXPORTING text = |parse_element: expected end|.
           ENDIF.
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 1.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 2.
@@ -147,15 +147,15 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
 
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 3.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             INSERT io_body->shift_u32( ) INTO TABLE ls_element-funcidx.
           ENDDO.
         WHEN 4.
@@ -172,8 +172,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
             RAISE EXCEPTION TYPE zcx_wasm EXPORTING text = |parse_element: expected end|.
           ENDIF.
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body
@@ -188,8 +188,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
         WHEN 5.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body
@@ -216,8 +216,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
 
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body
@@ -232,8 +232,8 @@ CLASS zcl_wasm_element_section IMPLEMENTATION.
         WHEN 7.
           ls_element-elemkind = io_body->shift( 1 ).
 
-          DATA(lv_times) = io_body->shift_u32( ).
-    DO lv_times TIMES.
+          lv_times = io_body->shift_u32( ).
+          DO lv_times TIMES.
             zcl_wasm_instructions=>parse(
               EXPORTING
                 io_body         = io_body

--- a/src/parsing/sections/zcl_wasm_function_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_function_section.clas.abap
@@ -16,7 +16,8 @@ CLASS zcl_wasm_function_section IMPLEMENTATION.
 * https://webassembly.github.io/spec/core/binary/modules.html#binary-funcsec
 
     DATA(lv_codeidx) = 0.
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       APPEND VALUE #(
         typeidx = io_body->shift_u32( )
         codeidx = lv_codeidx ) TO ct_functions.

--- a/src/parsing/sections/zcl_wasm_global_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_global_section.clas.abap
@@ -96,7 +96,8 @@ CLASS zcl_wasm_global_section IMPLEMENTATION.
     DATA lt_globals TYPE ty_globals.
     DATA ls_global  LIKE LINE OF lt_globals.
 
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       CLEAR ls_global.
       ls_global-type = io_body->shift( 1 ).
       ls_global-mut = io_body->shift( 1 ).

--- a/src/parsing/sections/zcl_wasm_import_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_import_section.clas.abap
@@ -70,7 +70,8 @@ CLASS zcl_wasm_import_section IMPLEMENTATION.
     DATA lt_imports TYPE ty_imports_tt.
     DATA ls_import LIKE LINE OF lt_imports.
 
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       CLEAR ls_import.
 
       ls_import-module = io_body->shift_utf8( ).

--- a/src/parsing/sections/zcl_wasm_table_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_table_section.clas.abap
@@ -37,7 +37,8 @@ CLASS zcl_wasm_table_section IMPLEMENTATION.
 
     ro_section = NEW zcl_wasm_table_section( ).
 
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       CLEAR ls_table.
       ls_table-reftype = io_body->shift( 1 ).
 

--- a/src/parsing/sections/zcl_wasm_type_section.clas.abap
+++ b/src/parsing/sections/zcl_wasm_type_section.clas.abap
@@ -15,7 +15,8 @@ CLASS zcl_wasm_type_section IMPLEMENTATION.
 
 * https://webassembly.github.io/spec/core/binary/modules.html#type-section
 
-    DO io_body->shift_u32( ) TIMES.
+    DATA(lv_times) = io_body->shift_u32( ).
+    DO lv_times TIMES.
       IF io_body->shift( 1 ) <> zif_wasm_types=>c_function_type.
         RAISE EXCEPTION TYPE zcx_wasm EXPORTING text = |parse type section, expected function type|.
       ENDIF.


### PR DESCRIPTION
in case this is interesting for you:
i needed to fix the following for abap 752:
```
do call->method() times. 
enddo. 
```
Now it works on ABAP Developer Edition.